### PR TITLE
lyrics command grabs current song

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -492,7 +492,13 @@ class Music(commands.Cog):
 
 
     @commands.command(help="This command shows lyrics for a song. You input the title and the bot tries to find the lyrics for that song", extras={"category":"Search"}, usage="lyrics [song name]", description="Song lyrics command")
-    async def lyrics(self, ctx, *, song):
+    async def lyrics(self, ctx, *, song = None):
+        if song is None:
+            try:
+                song = ctx.voice_state.current.source.title
+            except:
+                return await ctx.send("No song was provided")
+        
         url = "https://some-random-api.ml/lyrics"
         song = song.replace(" ", "+")
         data = {


### PR DESCRIPTION
if a user uses the lyrics command without specifying any song the bot will attempt to grab the current song,
the name it uses is the same name that appears in the now playing segment for the play and now command

example:
![image](https://user-images.githubusercontent.com/47639983/171254631-a9652e80-fc97-4483-b0c1-27cd15885cba.png)
